### PR TITLE
Fix for saving a string of "01234" and getting 1234 back in afterFind() ...

### DIFF
--- a/Model/Behavior/ExpandableBehavior.php
+++ b/Model/Behavior/ExpandableBehavior.php
@@ -297,6 +297,10 @@ class ExpandableBehavior extends ModelBehavior {
 		if ($value == 'null') {
 			return null;
 		}
+		# Work around for php behavior:  json_decode("01234") -> 1234.  Losing the leading zero value even if it's a string.
+		if (is_string($value) && preg_match('/^0\d+$/', $value)) {
+			return $value;
+		}
 		$decoded = @json_decode($value, true);
 		if ($decoded != null) {
 			return $decoded;


### PR DESCRIPTION
...- tweak to decode()
