### PR TITLE
Fixing composer to not require CakePHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 		}
 	],
 	"require": {
-		"cakephp/cakephp": "~2.0",
 		"composer/installers": "~1.0",
 		"php": ">=5.2.8"
 	}


### PR DESCRIPTION
Since this project is a CakePHP Plugin its best to not require cakephp in the composer file since it's implied that CakePHP is installed if you are installing a CakePHP Plugin. Having this require duplicates the cakephp libs folder and wastes space. You can look at other major plugins and see their composer file does not require cakephp https://github.com/CakeDC/migrations/blob/master/composer.json https://github.com/cakephp/debug_kit/blob/master/composer.json
